### PR TITLE
chore: standardize package names in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,8 @@ langchain==0.1.20
 nltk==3.8.1
 numpy==1.26.4
 ratelimit==2.2.1
-Requests==2.31.0
-scikit_learn==1.5.0
+requests==2.31.0
+scikit-learn==1.5.0
 starlette==0.37.2
 tenacity==8.3.0
 tqdm==4.66.1


### PR DESCRIPTION
## Summary
- Change `Requests` to `requests` (canonical PyPI name)
- Change `scikit_learn` to `scikit-learn` (canonical PyPI name)

This ensures consistency with PyPI package naming conventions and avoids potential issues with case-sensitive package managers.

## Test plan
- [x] Verify package names match canonical PyPI names
- [x] No functional changes, naming only