### PR TITLE
fix: prevent RuntimeError when filtering financials in FinnHubUtils

### DIFF
--- a/finrobot/data_source/finnhub_utils.py
+++ b/finrobot/data_source/finnhub_utils.py
@@ -150,9 +150,8 @@ class FinnHubUtils:
             value = value_list[0]
             output_dict.update({metric: value["v"]})
 
-        for k in output_dict.keys():
-            if selected_columns and k not in selected_columns:
-                output_dict.pop(k)
+        if selected_columns:
+            output_dict = {k: v for k, v in output_dict.items() if k in selected_columns}
 
         return json.dumps(output_dict, indent=2)
 


### PR DESCRIPTION
## Summary
Fix a bug in `FinnHubUtils.get_basic_financials()` that causes a `RuntimeError` when `selected_columns` is provided.

### The Bug
The original code modified a dictionary while iterating over its keys:

```python
for k in output_dict.keys():
    if selected_columns and k not in selected_columns:
        output_dict.pop(k)  # RuntimeError: dictionary changed size during iteration
```

### The Fix
Replace the problematic loop with a dict comprehension that creates a new filtered dictionary:

```python
if selected_columns:
    output_dict = {k: v for k, v in output_dict.items() if k in selected_columns}
```

## Test plan
- [x] Verify the fix compiles without syntax errors
- [ ] Test `FinnHubUtils.get_basic_financials("AAPL", selected_columns=["eps", "pe"])` no longer crashes