### PR TITLE
fix: improve error messages and exception handling in sec_utils.py

### DIFF
--- a/finrobot/data_source/sec_utils.py
+++ b/finrobot/data_source/sec_utils.py
@@ -84,10 +84,10 @@ class SECUtils:
                 with open(file_path, "w") as f:
                     f.write(file_content)
                 return f"{ticker}: download succeeded. Saved to {file_path}"
-            except:
-                return f"❌ {ticker}: downloaded failed: {url}"
+            except Exception as e:
+                return f"❌ {ticker}: download failed: {url} - {e}"
         else:
-            return f"No 2023 10-K filing found for {ticker}"
+            return f"No 10-K filing found for {ticker} between {start_date} and {end_date}"
 
     def download_10k_pdf(
         ticker: Annotated[str, "ticker symbol"],
@@ -132,9 +132,9 @@ class SECUtils:
                         file.write(chunk)
                 return f"{ticker}: download succeeded. Saved to {file_path}"
             except Exception as e:
-                return f"❌ {ticker}: downloaded failed: {filing_url}, {e}"
+                return f"❌ {ticker}: download failed: {filing_url} - {e}"
         else:
-            return f"No 2023 10-K filing found for {ticker}"
+            return f"No 10-K filing found for {ticker} between {start_date} and {end_date}"
 
     def get_10k_section(
         ticker_symbol: Annotated[str, "ticker symbol"],


### PR DESCRIPTION
## Summary
Improve error handling and messages in `SECUtils.download_10k_filing()` and `SECUtils.download_10k_pdf()`.

### Changes
1. **Replace hardcoded year in error messages**
   - Before: `"No 2023 10-K filing found for {ticker}"`
   - After: `"No 10-K filing found for {ticker} between {start_date} and {end_date}"`
   
2. **Improve exception handling**
   - Replace bare `except:` with `except Exception as e:` to capture and display the actual error
   
3. **Fix typo**
   - "downloaded failed" -> "download failed"

4. **Consistent formatting**
   - Use hyphen separator for error details: `{url} - {e}`

## Test plan
- [x] Verify error messages now show the actual search date range
- [x] Verify exception details are included in error output
- [x] No functional changes to success paths