### PR TITLE
feat: add retail sentiment insights to equity reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Edit `config.ini` with your keys:
 [API_KEYS]
 fmp_api_key = YOUR_FMP_API_KEY          # https://financialmodelingprep.com/developer
 openai_api_key = YOUR_OPENAI_API_KEY    # https://platform.openai.com/account/api-keys
+adanos_api_key = YOUR_ADANOS_API_KEY    # Optional: enables Retail Sentiment Insights
 ```
 
 **2. One-Command Deploy (Web Interface)**
@@ -349,6 +350,5 @@ year={2024}
 <div align="center">
 <img align="center" width="30%" alt="image" src="https://github.com/AI4Finance-Foundation/FinGPT/assets/31713746/e0371951-1ce1-488e-aa25-0992dafcc139">
 </div>
-
 
 

--- a/finrobot_equity/README.md
+++ b/finrobot_equity/README.md
@@ -30,6 +30,7 @@ finrobot_equity/
 │   │       ├── sensitivity_analyzer.py      #   Sensitivity analysis
 │   │       ├── catalyst_analyzer.py         #   Market catalyst identification
 │   │       ├── news_integrator.py           #   News data integration
+│   │       ├── retail_sentiment_client.py   #   Optional retail sentiment insights
 │   │       ├── valuation_engine.py          #   Valuation modeling
 │   │       ├── pdf_generator.py             #   PDF report generation
 │   │       ├── professional_pdf_report.py   #   Professional PDF templates
@@ -94,7 +95,10 @@ Edit `config.ini` with your keys:
 [API_KEYS]
 fmp_api_key = YOUR_FMP_API_KEY          # https://financialmodelingprep.com/developer
 openai_api_key = YOUR_OPENAI_API_KEY    # https://platform.openai.com/account/api-keys
+adanos_api_key = YOUR_ADANOS_API_KEY    # Optional: enables Retail Sentiment Insights
 ```
+
+If `adanos_api_key` is configured, the report pipeline adds an optional **Retail Sentiment Insights** layer to the equity research output. It supplements the existing news workflow with structured public-retail activity snapshots across Reddit, X.com, and Polymarket.
 
 ### 2. Deploy via Script
 
@@ -161,6 +165,7 @@ python finrobot_equity/core/src/create_equity_report.py \
 |:---|:---|:---|
 | [Financial Modeling Prep](https://financialmodelingprep.com/developer) | Yes | Financial data, market metrics, peer comparison |
 | [OpenAI](https://platform.openai.com/) | Yes | AI-powered text generation for report sections |
+| Adanos Finance API | No | Optional retail sentiment insights for Reddit, X.com, and Polymarket |
 
 ## License
 

--- a/finrobot_equity/core/config/config.ini.example
+++ b/finrobot_equity/core/config/config.ini.example
@@ -21,3 +21,9 @@ openai_base_url = https://api.openai.com/v1
 # Default: gpt-4.1-mini
 openai_model = gpt-4.1
 
+# Adanos Finance API key (optional, enables retail sentiment insights in equity reports)
+adanos_api_key = YOUR_ADANOS_API_KEY
+
+# Adanos base URL (optional)
+# Default: https://api.adanos.org
+adanos_base_url = https://api.adanos.org

--- a/finrobot_equity/core/src/create_equity_report.py
+++ b/finrobot_equity/core/src/create_equity_report.py
@@ -371,6 +371,7 @@ def main():
     parser.add_argument("--sensitivity-analysis-file", type=str, default=None, help="Path to sensitivity analysis JSON file.")
     parser.add_argument("--catalyst-analysis-file", type=str, default=None, help="Path to catalyst analysis JSON file.")
     parser.add_argument("--enhanced-news-file", type=str, default=None, help="Path to enhanced news JSON file.")
+    parser.add_argument("--retail-sentiment-file", type=str, default=None, help="Path to retail sentiment JSON file.")
 
     args = parser.parse_args()
 
@@ -537,6 +538,7 @@ def main():
         "analyst_emails": args.analyst_emails,
         "closing_price_date": args.closing_price_date,
         "technical_indicators": technical_indicators,
+        "retail_sentiment": {},
     }
 
     # --- Generate or load charts ---
@@ -874,6 +876,22 @@ def main():
         except Exception as e:
             print(f"⚠️ Error loading enhanced news: {e}")
             report_data['enhanced_news'] = {}
+
+    retail_sentiment_path = args.retail_sentiment_file
+    if not retail_sentiment_path:
+        candidate_path = os.path.join(os.path.dirname(args.analysis_csv), "retail_sentiment.json")
+        if os.path.exists(candidate_path):
+            retail_sentiment_path = candidate_path
+
+    if retail_sentiment_path and os.path.exists(retail_sentiment_path):
+        print(f"Loading retail sentiment insights from {retail_sentiment_path}...")
+        try:
+            with open(retail_sentiment_path, "r", encoding="utf-8") as f:
+                report_data["retail_sentiment"] = json.load(f)
+            print("✅ Retail sentiment insights loaded")
+        except Exception as e:
+            print(f"⚠️ Error loading retail sentiment insights: {e}")
+            report_data["retail_sentiment"] = {}
 
     # --- Format tables for HTML (EXCLUDE ESTIMATES FOR PAGE 3 TABLES) ---
     print("Formatting tables for HTML...")

--- a/finrobot_equity/core/src/create_equity_report.py
+++ b/finrobot_equity/core/src/create_equity_report.py
@@ -38,8 +38,6 @@ from modules.valuation_engine import ValuationEngine
 from modules.report_structure import ReportStructureManager
 from modules.enhanced_text_generator import EnhancedTextGenerator
 
-import pandas as pd
-
 def load_credit_cashflow_metrics_from_csv(file_path: str) -> pd.DataFrame:
     """Load credit and cashflow metrics from a pre-computed CSV file."""
     if not file_path or not os.path.exists(file_path):

--- a/finrobot_equity/core/src/generate_financial_analysis.py
+++ b/finrobot_equity/core/src/generate_financial_analysis.py
@@ -20,6 +20,7 @@ from modules.text_generator_agents import generate_text_section
 from modules.sensitivity_analyzer import SensitivityAnalyzer
 from modules.catalyst_analyzer import CatalystAnalyzer
 from modules.news_integrator import NewsIntegrator, get_enhanced_company_news
+from modules.retail_sentiment_client import RetailSentimentClient
 
 def main():
     parser = argparse.ArgumentParser(description="Generate financial analysis data using FMP API instead of PDF extraction.")
@@ -46,6 +47,7 @@ def main():
     # NEWS PARAMETERS
     parser.add_argument("--news-days-back", type=int, default=5, help="Number of days to look back for company news (default: 5)")
     parser.add_argument("--news-limit", type=int, default=50, help="Maximum number of news articles to fetch (default: 50)")
+    parser.add_argument("--retail-sentiment-days-back", type=int, default=7, help="Number of days to look back for retail sentiment insights (default: 7)")
 
     # 新增分析选项
     parser.add_argument("--enable-sensitivity-analysis", action="store_true", help="Enable sensitivity analysis for forecasts")
@@ -80,9 +82,13 @@ def main():
 
     # Load configuration and API keys
     openai_base_url = None
+    adanos_api_key = os.getenv("ADANOS_API_KEY")
+    adanos_base_url = os.getenv("ADANOS_BASE_URL", "https://api.adanos.org")
     try:
         config = load_config(args.config_file)
         fmp_api_key = get_api_key(config, section="API_KEYS", key="fmp_api_key")
+        adanos_api_key = config.get("API_KEYS", "adanos_api_key", fallback=adanos_api_key)
+        adanos_base_url = config.get("API_KEYS", "adanos_base_url", fallback=adanos_base_url)
         if args.generate_text_sections:
             openai_api_key = get_api_key(config, section="API_KEYS", key="openai_api_key")
             # Try to get base_url for proxy services (like SiliconFlow)
@@ -267,6 +273,30 @@ def main():
     else:
         print("Skipping news fetch (no FMP API key)")
 
+    # 4.55 Fetch Retail Sentiment Insights
+    retail_sentiment_data = None
+    if adanos_api_key:
+        print(f"\nFetching retail sentiment insights for {args.company_ticker}...")
+        try:
+            retail_client = RetailSentimentClient(
+                api_key=adanos_api_key,
+                base_url=adanos_base_url,
+            )
+            retail_sentiment_data = retail_client.get_snapshot(
+                args.company_ticker,
+                days_back=args.retail_sentiment_days_back,
+            )
+
+            retail_sentiment_path = os.path.join(output_dir, "retail_sentiment.json")
+            with open(retail_sentiment_path, "w", encoding="utf-8") as f:
+                json.dump(retail_sentiment_data, f, indent=2, ensure_ascii=False)
+            print(f"Saved retail sentiment insights to: {retail_sentiment_path}")
+        except Exception as e:
+            print(f"Error fetching retail sentiment insights: {e}")
+            print("Continuing without retail sentiment insights...")
+    else:
+        print("Skipping retail sentiment insights (no ADANOS_API_KEY / adanos_api_key configured)")
+
     # 4.6 敏感性分析
     sensitivity_results = None
     if args.enable_sensitivity_analysis:
@@ -379,6 +409,7 @@ def main():
                 "peer_ev_ebitda": df_ev_ebitda_peers,
                 "company_news": company_news,
                 "enhanced_news": enhanced_news_data,
+                "retail_sentiment": retail_sentiment_data,
                 "sensitivity_analysis": sensitivity_results,
                 "catalyst_analysis": catalyst_results
             }

--- a/finrobot_equity/core/src/modules/html_renderer.py
+++ b/finrobot_equity/core/src/modules/html_renderer.py
@@ -885,6 +885,55 @@ def format_analyst_contacts(names, emails):
         html.append(f'<p class="text-gray-500">{name} | {email}</p>')
     return "\n".join(html)
 
+
+def format_retail_sentiment_html(sentiment_data: dict) -> str:
+    """Format retail sentiment insights for legacy and combined HTML templates."""
+    if not sentiment_data or not sentiment_data.get("sources"):
+        return ""
+
+    summary_items = []
+    if sentiment_data.get("average_buzz") is not None:
+        summary_items.append(f"Average Buzz: {sentiment_data['average_buzz']}/100")
+    if sentiment_data.get("bullish_avg") is not None:
+        summary_items.append(f"Bullish Avg: {sentiment_data['bullish_avg']}%")
+    summary_items.append(f"Source Alignment: {sentiment_data.get('source_alignment', 'No coverage')}")
+    summary_items.append(f"Coverage: {sentiment_data.get('coverage', '0/3')}")
+
+    source_rows = []
+    for source in sentiment_data.get("sources", []):
+        if not source.get("has_data"):
+            continue
+        bullish = (
+            f"{source['bullish_pct']}%"
+            if source.get("bullish_pct") is not None
+            else "N/A"
+        )
+        source_rows.append(
+            "<li style=\"font-size:10px; color:#1a1a1a; margin-bottom:2px;\">"
+            f"<strong>{source['label']}</strong>: "
+            f"Buzz {source.get('buzz_score', 'N/A')}/100, "
+            f"Bullish {bullish}, "
+            f"{source.get('activity_label', 'Activity')} {source.get('activity_value', 0)}, "
+            f"Trend {source.get('trend', 'n/a')}"
+            "</li>"
+        )
+
+    if not source_rows:
+        return ""
+
+    summary_html = " &middot; ".join(summary_items)
+    sources_html = "".join(source_rows)
+
+    return (
+        "<div style=\"background:#f5f7fa; border-top:2px solid #8B6914; padding:12px 16px; margin:12px 0;\">"
+        "<h3 style=\"font-size:11px; font-weight:600; color:#002855; text-transform:uppercase; letter-spacing:0.03em; margin:0 0 8px 0;\">"
+        "Retail Sentiment Insights"
+        "</h3>"
+        f"<p style=\"font-size:10px; color:#555555; margin:0 0 8px 0;\">{summary_html}</p>"
+        f"<ul style=\"list-style:none; padding-left:0; margin:0;\">{sources_html}</ul>"
+        "</div>"
+    )
+
 def render_html_report(template_str: str, data: dict) -> str:
     """Renders an HTML report from a template string and data dictionary."""
     try:
@@ -910,6 +959,7 @@ def render_html_report(template_str: str, data: dict) -> str:
         data.setdefault("peer_ev_ebitda_table_html", "<p>Peer EV/EBITDA data not available.</p>")
         data.setdefault("credit_cashflow_table_html", "<p>Credit & Cashflow metrics not available.</p>")
         data.setdefault("news_summary", "Recent news coverage not available.")
+        data["retail_sentiment_html"] = format_retail_sentiment_html(data.get("retail_sentiment", {}))
         
         # Safely format enhanced analysis data for Page 4
         # Wrap each call in try-except to prevent one failure from breaking everything
@@ -1083,6 +1133,7 @@ HTML_TEMPLATE_COMBINED = """
           <div class="mb-4 text-xs leading-tight" style="color: #1a1a1a;">{investment_overview}</div>
           <h3 class="section-label">Recent News Summary</h3>
           <div class="mb-4 text-xs leading-tight" style="color: #1a1a1a;">{news_summary}</div>
+          {retail_sentiment_html}
           <h3 class="section-label">Valuation</h3>
           <div class="mb-4 text-xs leading-tight" style="color: #1a1a1a;">{valuation_overview}</div>
           {valuation_breakdown_html}
@@ -1181,6 +1232,9 @@ HTML_TEMPLATE_COMBINED = """
         <h1 class="text-xl font-normal" style="font-family: 'Georgia', 'Times New Roman', serif; letter-spacing: 0.03em;">NEWS & ENHANCED CHARTS</h1>
       </div>
       <div class="mb-6">
+        <div class="text-xs leading-tight">{retail_sentiment_html}</div>
+      </div>
+      <div class="mb-6">
         <h2 class="section-label mb-3">News Impact Analysis</h2>
         <div class="text-xs leading-tight">{enhanced_news_html}</div>
       </div>
@@ -1234,6 +1288,7 @@ def render_combined_html_report(data: dict) -> str:
         data.setdefault("peer_ev_ebitda_table_html_comp", data.get("peer_ev_ebitda_table_html", "<p>Peer EV/EBITDA data not available.</p>"))
         data.setdefault("credit_cashflow_table_html", "<p>Credit & Cashflow metrics not available.</p>")
         data.setdefault("news_summary", "Recent news coverage not available.")
+        data["retail_sentiment_html"] = format_retail_sentiment_html(data.get("retail_sentiment", {}))
 
         # Convert text fields to HTML with auto-bold
         for key in ['company_overview', 'investment_overview', 'valuation_overview',

--- a/finrobot_equity/core/src/modules/html_template_professional.py
+++ b/finrobot_equity/core/src/modules/html_template_professional.py
@@ -430,6 +430,7 @@ HTML_PROFESSIONAL_TEMPLATE = """
             <div class="content-card">
                 <h3 class="heading-3" style="margin-top:0;">News Summary</h3>
                 <div class="body-text">{news_summary}</div>
+                {retail_sentiment_html}
                 {enhanced_news_html}
             </div>
         </section>
@@ -661,6 +662,59 @@ def format_catalyst_analysis_html_professional(catalyst_data: dict) -> str:
             html += '</div>'
 
     return html if html else "<p class='body-text' style='color:#94a3b8; font-style:italic;'>Catalyst analysis not available.</p>"
+
+
+def format_retail_sentiment_html_professional(sentiment_data: dict) -> str:
+    """Format retail sentiment insights for the professional HTML report."""
+    if not sentiment_data:
+        return ""
+
+    avg_buzz = sentiment_data.get("average_buzz")
+    bullish_avg = sentiment_data.get("bullish_avg")
+    coverage = sentiment_data.get("coverage", "0/3")
+    alignment = sentiment_data.get("source_alignment", "No coverage")
+    sources = sentiment_data.get("sources", [])
+
+    html = '<h3 class="heading-3">Retail Sentiment Insights</h3>'
+    html += '<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(140px, 1fr)); gap:0.75rem; margin-bottom:0.75rem;">'
+
+    summary_cards = [
+        ("Average Buzz", f"{avg_buzz}/100" if avg_buzz is not None else "N/A"),
+        ("Bullish Avg", f"{bullish_avg}%" if bullish_avg is not None else "N/A"),
+        ("Source Alignment", alignment),
+        ("Coverage", coverage),
+    ]
+    for label, value in summary_cards:
+        html += (
+            '<div style="background:#f8fafc; border:1px solid #e2e8f0; border-radius:0.625rem; '
+            'padding:0.7rem 0.85rem;">'
+            f'<div style="font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em; color:#64748b; margin-bottom:0.25rem;">{label}</div>'
+            f'<div style="font-size:0.95rem; font-weight:600; color:#0f172a;">{value}</div>'
+            '</div>'
+        )
+    html += '</div>'
+
+    visible_sources = [source for source in sources if source.get("has_data")]
+    if visible_sources:
+        html += '<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:0.75rem; margin-bottom:0.5rem;">'
+        for source in visible_sources:
+            bullish_text = (
+                f"{source['bullish_pct']}%"
+                if source.get("bullish_pct") is not None
+                else "N/A"
+            )
+            html += (
+                '<div style="background:#ffffff; border:1px solid #e2e8f0; border-radius:0.625rem; padding:0.75rem 0.85rem;">'
+                f'<div style="font-size:0.82rem; font-weight:700; color:#0f172a; margin-bottom:0.45rem;">{source["label"]}</div>'
+                f'<div style="font-size:0.78rem; color:#475569;">Buzz <strong>{source["buzz_score"]}/100</strong></div>'
+                f'<div style="font-size:0.78rem; color:#475569;">Bullish <strong>{bullish_text}</strong></div>'
+                f'<div style="font-size:0.78rem; color:#475569;">{source["activity_label"]} <strong>{source["activity_value"]}</strong></div>'
+                f'<div style="font-size:0.78rem; color:#475569;">Trend <strong>{source["trend"]}</strong></div>'
+                '</div>'
+            )
+        html += '</div>'
+
+    return html
 
 
 def format_enhanced_news_html_professional(news_data: dict) -> str:
@@ -983,6 +1037,7 @@ def render_professional_html_report(data: dict) -> str:
         'peer_ev_ebitda_table_html': data.get('peer_ev_ebitda_table_html', '<p class="body-text" style="color:#94a3b8; font-style:italic;">Peer comparison data not available.</p>'),
         'ev_ebitda_chart_path': data.get('ev_ebitda_chart_path', ''),
         'news_summary': _markdown_to_html(data.get('news_summary', 'Recent news coverage not available.')),
+        'retail_sentiment_html': format_retail_sentiment_html_professional(data.get('retail_sentiment', {})),
         'enhanced_news_html': format_enhanced_news_html_professional(data.get('enhanced_news', {})),
         'sensitivity_analysis_html': format_sensitivity_analysis_html_professional(data.get('sensitivity_analysis', {})),
         'catalyst_analysis_html': format_catalyst_analysis_html_professional(data.get('catalyst_analysis', {})),

--- a/finrobot_equity/core/src/modules/professional_pdf_report.py
+++ b/finrobot_equity/core/src/modules/professional_pdf_report.py
@@ -828,10 +828,11 @@ class ProfessionalEquityReport:
         """构建新闻分析部分"""
         news_summary = self.data.get('news_summary', '')
         enhanced_news = self.data.get('enhanced_news', {})
+        retail_sentiment = self.data.get('retail_sentiment', {})
         company_news = self.data.get('company_news', [])
         
         # 如果没有新闻数据，跳过
-        if not news_summary and not enhanced_news:
+        if not news_summary and not enhanced_news and not retail_sentiment:
             return
         
         self.elements.append(Spacer(1, 8*mm))
@@ -871,6 +872,40 @@ class ProfessionalEquityReport:
                 self.elements.append(Paragraph("News by Category:", self.styles['BodyBold']))
                 for cat, count in enhanced_news['categories'].items():
                     self.elements.append(Paragraph(f"• {cat}: {count} articles", self.styles['BulletPoint']))
+
+        if retail_sentiment:
+            self.elements.append(Spacer(1, 4 * mm))
+            self.elements.append(Paragraph("Retail Sentiment Insights", self.styles['Heading2']))
+
+            summary_items = []
+            if retail_sentiment.get('average_buzz') is not None:
+                summary_items.append(f"Average Buzz: {retail_sentiment['average_buzz']}/100")
+            if retail_sentiment.get('bullish_avg') is not None:
+                summary_items.append(f"Bullish Avg: {retail_sentiment['bullish_avg']}%")
+            summary_items.append(f"Source Alignment: {retail_sentiment.get('source_alignment', 'No coverage')}")
+            summary_items.append(f"Coverage: {retail_sentiment.get('coverage', '0/3')}")
+
+            for item in summary_items:
+                self.elements.append(Paragraph(f"• {item}", self.styles['BulletPoint']))
+
+            for source in retail_sentiment.get('sources', []):
+                if not source.get('has_data'):
+                    continue
+                bullish_text = (
+                    f"{source['bullish_pct']}%"
+                    if source.get('bullish_pct') is not None
+                    else 'N/A'
+                )
+                self.elements.append(
+                    Paragraph(
+                        f"{source['label']}: Buzz {source['buzz_score']}/100, "
+                        f"Bullish {bullish_text}, "
+                        f"{source['activity_label']} {source['activity_value']}, "
+                        f"Trend {source['trend']}",
+                        self.styles['Body'],
+                    )
+                )
+                self.elements.append(Spacer(1, 1.5 * mm))
         
         # Recent Headlines 已禁用 - 不显示单条新闻标题列表
         # if company_news and len(company_news) > 0:

--- a/finrobot_equity/core/src/modules/retail_sentiment_client.py
+++ b/finrobot_equity/core/src/modules/retail_sentiment_client.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""Optional Adanos-backed retail sentiment snapshot for US stock reports."""
+
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+class RetailSentimentClient:
+    """Fetch structured retail sentiment snapshots for one stock ticker."""
+
+    PLATFORM_SPECS = (
+        {
+            "key": "reddit",
+            "label": "Reddit",
+            "path": "/reddit/stocks/v1/compare",
+            "activity_field": "mentions",
+            "activity_label": "Mentions",
+        },
+        {
+            "key": "x",
+            "label": "X.com",
+            "path": "/x/stocks/v1/compare",
+            "activity_field": "mentions",
+            "activity_label": "Mentions",
+        },
+        {
+            "key": "polymarket",
+            "label": "Polymarket",
+            "path": "/polymarket/stocks/v1/compare",
+            "activity_field": "trade_count",
+            "activity_label": "Trades",
+        },
+    )
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.adanos.org",
+        timeout: int = 10,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def get_snapshot(self, ticker: str, days_back: int = 7) -> Dict[str, Any]:
+        """Return a compact retail sentiment snapshot across public sources."""
+        normalized_ticker = ticker.strip().upper().replace("$", "")
+        sources: List[Dict[str, Any]] = []
+
+        for spec in self.PLATFORM_SPECS:
+            try:
+                row = self._fetch_source_row(spec, normalized_ticker, days_back)
+            except Exception as exc:
+                print(
+                    f"Warning: Failed to fetch retail sentiment for {normalized_ticker} "
+                    f"from {spec['label']}: {exc}"
+                )
+                row = None
+            sources.append(self._normalize_source(spec, row))
+
+        covered_sources = [source for source in sources if source["has_data"]]
+        buzz_values = [source["buzz_score"] for source in covered_sources]
+        bullish_values = [
+            source["bullish_pct"]
+            for source in covered_sources
+            if source["bullish_pct"] is not None
+        ]
+
+        return {
+            "ticker": normalized_ticker,
+            "period_days": days_back,
+            "coverage": f"{len(covered_sources)}/{len(self.PLATFORM_SPECS)}",
+            "coverage_ratio": round(len(covered_sources) / len(self.PLATFORM_SPECS), 2),
+            "average_buzz": round(mean(buzz_values), 1) if buzz_values else None,
+            "bullish_avg": round(mean(bullish_values), 1) if bullish_values else None,
+            "source_alignment": self._compute_source_alignment(bullish_values),
+            "sources": sources,
+        }
+
+    def _fetch_source_row(
+        self,
+        spec: Dict[str, str],
+        ticker: str,
+        days_back: int,
+    ) -> Optional[Dict[str, Any]]:
+        response = requests.get(
+            f"{self.base_url}{spec['path']}",
+            params={"tickers": ticker, "days": days_back},
+            headers={"X-API-Key": self.api_key},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        for item in payload.get("stocks", []):
+            item_ticker = str(item.get("ticker") or "").strip().upper().replace("$", "")
+            if item_ticker == ticker:
+                return item
+
+        return None
+
+    def _normalize_source(
+        self,
+        spec: Dict[str, str],
+        row: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        buzz_score = self._safe_float(row.get("buzz_score")) if row else 0.0
+        bullish_pct = self._safe_float(row.get("bullish_pct")) if row else None
+        activity_value = self._safe_int(row.get(spec["activity_field"])) if row else 0
+        trend = row.get("trend") if row else None
+
+        has_data = bool(
+            buzz_score > 0
+            or activity_value > 0
+            or bullish_pct is not None
+        )
+
+        return {
+            "key": spec["key"],
+            "label": spec["label"],
+            "buzz_score": round(buzz_score, 1),
+            "bullish_pct": round(bullish_pct, 1) if bullish_pct is not None else None,
+            "activity_label": spec["activity_label"],
+            "activity_value": activity_value,
+            "trend": trend or "n/a",
+            "has_data": has_data,
+        }
+
+    @staticmethod
+    def _compute_source_alignment(bullish_values: List[float]) -> str:
+        if not bullish_values:
+            return "No coverage"
+        if len(bullish_values) == 1:
+            return "Single-source signal"
+
+        avg_value = mean(bullish_values)
+        spread = max(bullish_values) - min(bullish_values)
+
+        if spread <= 10:
+            if avg_value >= 55:
+                return "Bullish alignment"
+            if avg_value <= 45:
+                return "Bearish alignment"
+            return "Neutral alignment"
+        if spread <= 20:
+            return "Partial divergence"
+        return "Wide divergence"
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        if value is None or value == "":
+            return 0
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return 0
+
+
+def format_retail_sentiment_for_prompt(snapshot: Dict[str, Any]) -> str:
+    """Render a compact plain-text summary for the news summary prompt."""
+    if not snapshot:
+        return ""
+
+    lines = [
+        "## Retail Sentiment Insights",
+        f"- Average Buzz: {snapshot.get('average_buzz', 'N/A')}/100" if snapshot.get("average_buzz") is not None else "- Average Buzz: N/A",
+        f"- Bullish Avg: {snapshot.get('bullish_avg', 'N/A')}%" if snapshot.get("bullish_avg") is not None else "- Bullish Avg: N/A",
+        f"- Source Alignment: {snapshot.get('source_alignment', 'N/A')}",
+        f"- Coverage: {snapshot.get('coverage', '0/3')}",
+    ]
+
+    for source in snapshot.get("sources", []):
+        if not source.get("has_data"):
+            continue
+        bullish = (
+            f"{source['bullish_pct']}%"
+            if source.get("bullish_pct") is not None
+            else "N/A"
+        )
+        lines.append(
+            f"- {source['label']}: buzz {source['buzz_score']}/100, "
+            f"bullish {bullish}, "
+            f"{source['activity_label'].lower()} {source['activity_value']}, "
+            f"trend {source['trend']}"
+        )
+
+    return "\n".join(lines)

--- a/finrobot_equity/core/src/modules/text_generator_agents.py
+++ b/finrobot_equity/core/src/modules/text_generator_agents.py
@@ -6,6 +6,8 @@ import pandas as pd
 from typing import Dict, Optional
 from openai import OpenAI
 
+from modules.retail_sentiment_client import format_retail_sentiment_for_prompt
+
 
 def _get_fallback_text(prompt_type: str, company_name: str) -> str:
     """Returns fallback text when agent generation fails."""
@@ -52,6 +54,7 @@ def _prepare_user_prompt(data: Dict, prompt_type: str, company_name: str, compan
     peer_ebitda = data.get('peer_ebitda')
     peer_ev_ebitda = data.get('peer_ev_ebitda')
     company_news = data.get('company_news')
+    retail_sentiment = data.get('retail_sentiment')
     
     prompt = f"Company: {company_name} ({company_ticker})\n\n"
     
@@ -69,7 +72,10 @@ def _prepare_user_prompt(data: Dict, prompt_type: str, company_name: str, compan
         for i, article in enumerate(company_news[:10], 1):  # Limit to 10 articles
             prompt += f"{i}. {article.get('title', 'N/A')} ({article.get('publishedDate', 'N/A')[:10]})\n"
             prompt += f"   {article.get('text', 'N/A')[:200]}...\n\n"
-    
+
+    if prompt_type == "news_summary" and retail_sentiment:
+        prompt += "\n" + format_retail_sentiment_for_prompt(retail_sentiment) + "\n"
+
     prompt += f"\nPlease provide the {prompt_type.replace('_', ' ')} based on the above data."
     return prompt
 

--- a/finrobot_equity/core/src/modules/text_generator_agents.py
+++ b/finrobot_equity/core/src/modules/text_generator_agents.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import os
 import pandas as pd
 from typing import Dict, Optional
 from openai import OpenAI

--- a/finrobot_equity/core/tests/test_modules.py
+++ b/finrobot_equity/core/tests/test_modules.py
@@ -26,6 +26,7 @@ def test_import_modules():
         ('enhanced_text_generator', 'EnhancedTextGenerator'),
         ('report_structure', 'ReportStructureManager'),
         ('news_integrator', 'NewsIntegrator'),
+        ('retail_sentiment_client', 'RetailSentimentClient'),
     ]
     
     results = []

--- a/finrobot_equity/core/tests/test_retail_sentiment_client.py
+++ b/finrobot_equity/core/tests/test_retail_sentiment_client.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import sys
+
+import pytest
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from modules.retail_sentiment_client import (
+    RetailSentimentClient,
+    format_retail_sentiment_for_prompt,
+)
+from modules.html_renderer import format_retail_sentiment_html
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_get_snapshot_aggregates_available_sources(monkeypatch):
+    fixtures = {
+        "/reddit/stocks/v1/compare": {
+            "stocks": [
+                {
+                    "ticker": "TSLA",
+                    "buzz_score": 82.0,
+                    "bullish_pct": 58.0,
+                    "mentions": 1200,
+                    "trend": "rising",
+                }
+            ]
+        },
+        "/x/stocks/v1/compare": {
+            "stocks": [
+                {
+                    "ticker": "TSLA",
+                    "buzz_score": 76.0,
+                    "bullish_pct": 54.0,
+                    "mentions": 3400,
+                    "trend": "stable",
+                }
+            ]
+        },
+        "/polymarket/stocks/v1/compare": {
+            "stocks": [
+                {
+                    "ticker": "TSLA",
+                    "buzz_score": 68.0,
+                    "bullish_pct": 62.0,
+                    "trade_count": 480,
+                    "trend": "rising",
+                }
+            ]
+        },
+    }
+
+    def fake_get(url, **kwargs):
+        path = url.replace("https://api.adanos.org", "")
+        assert kwargs["params"]["tickers"] == "TSLA"
+        assert kwargs["params"]["days"] == 7
+        assert kwargs["headers"]["X-API-Key"] == "test-key"
+        return _Response(fixtures[path])
+
+    monkeypatch.setattr("modules.retail_sentiment_client.requests.get", fake_get)
+
+    snapshot = RetailSentimentClient(api_key="test-key").get_snapshot("tsla")
+
+    assert snapshot["ticker"] == "TSLA"
+    assert snapshot["coverage"] == "3/3"
+    assert snapshot["average_buzz"] == 75.3
+    assert snapshot["bullish_avg"] == 58.0
+    assert snapshot["source_alignment"] == "Bullish alignment"
+    assert [source["key"] for source in snapshot["sources"]] == [
+        "reddit",
+        "x",
+        "polymarket",
+    ]
+
+
+def test_get_snapshot_skips_failed_source(monkeypatch):
+    def fake_get(url, **kwargs):
+        if "reddit" in url:
+            raise RuntimeError("temporary upstream failure")
+        if "x" in url:
+            return _Response(
+                {
+                    "stocks": [
+                        {
+                            "ticker": "MSFT",
+                            "buzz_score": 71.0,
+                            "bullish_pct": 49.0,
+                            "mentions": 900,
+                            "trend": "stable",
+                        }
+                    ]
+                }
+            )
+        return _Response({"stocks": []})
+
+    monkeypatch.setattr("modules.retail_sentiment_client.requests.get", fake_get)
+
+    snapshot = RetailSentimentClient(api_key="test-key").get_snapshot("MSFT")
+
+    assert snapshot["coverage"] == "1/3"
+    assert snapshot["average_buzz"] == 71.0
+    assert snapshot["bullish_avg"] == 49.0
+    assert snapshot["source_alignment"] == "Single-source signal"
+    assert snapshot["sources"][0]["has_data"] is False
+    assert snapshot["sources"][1]["has_data"] is True
+
+
+def test_prompt_formatter_renders_retail_sentiment_snapshot():
+    prompt_block = format_retail_sentiment_for_prompt(
+        {
+            "average_buzz": 73.9,
+            "bullish_avg": 57.1,
+            "source_alignment": "Partial divergence",
+            "coverage": "2/3",
+            "sources": [
+                {
+                    "label": "Reddit",
+                    "buzz_score": 81.0,
+                    "bullish_pct": 61.0,
+                    "activity_label": "Mentions",
+                    "activity_value": 1450,
+                    "trend": "rising",
+                    "has_data": True,
+                },
+                {
+                    "label": "Polymarket",
+                    "buzz_score": 66.8,
+                    "bullish_pct": 53.2,
+                    "activity_label": "Trades",
+                    "activity_value": 320,
+                    "trend": "stable",
+                    "has_data": True,
+                },
+            ],
+        }
+    )
+
+    assert "## Retail Sentiment Insights" in prompt_block
+    assert "Average Buzz: 73.9/100" in prompt_block
+    assert "Bullish Avg: 57.1%" in prompt_block
+    assert "Source Alignment: Partial divergence" in prompt_block
+    assert "Reddit: buzz 81.0/100, bullish 61.0%, mentions 1450, trend rising" in prompt_block
+    assert "Polymarket: buzz 66.8/100, bullish 53.2%, trades 320, trend stable" in prompt_block
+
+
+def test_html_formatter_renders_retail_sentiment_block():
+    html = format_retail_sentiment_html(
+        {
+            "average_buzz": 70.3,
+            "bullish_avg": 52.4,
+            "source_alignment": "Neutral alignment",
+            "coverage": "2/3",
+            "sources": [
+                {
+                    "label": "Reddit",
+                    "buzz_score": 72.0,
+                    "bullish_pct": 49.0,
+                    "activity_label": "Mentions",
+                    "activity_value": 840,
+                    "trend": "stable",
+                    "has_data": True,
+                }
+            ],
+        }
+    )
+
+    assert "Retail Sentiment Insights" in html
+    assert "Average Buzz: 70.3/100" in html
+    assert "Source Alignment: Neutral alignment" in html
+    assert "Reddit" in html

--- a/finrobot_equity/core/tests/test_retail_sentiment_client.py
+++ b/finrobot_equity/core/tests/test_retail_sentiment_client.py
@@ -4,11 +4,9 @@
 import os
 import sys
 
-import pytest
-
-
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
 
+from modules.html_template_professional import render_professional_html_report
 from modules.retail_sentiment_client import (
     RetailSentimentClient,
     format_retail_sentiment_for_prompt,
@@ -182,3 +180,37 @@ def test_html_formatter_renders_retail_sentiment_block():
     assert "Average Buzz: 70.3/100" in html
     assert "Source Alignment: Neutral alignment" in html
     assert "Reddit" in html
+
+
+def test_professional_report_renders_retail_sentiment_section():
+    html = render_professional_html_report(
+        {
+            "company_name_full": "Tesla, Inc.",
+            "company_ticker": "TSLA",
+            "share_price": "$180.00",
+            "target_price": "$210.00",
+            "news_summary": "Recent developments remain mixed.",
+            "retail_sentiment": {
+                "average_buzz": 74.4,
+                "bullish_avg": 58.8,
+                "source_alignment": "Bullish alignment",
+                "coverage": "2/3",
+                "sources": [
+                    {
+                        "label": "Reddit",
+                        "buzz_score": 79.1,
+                        "bullish_pct": 55.0,
+                        "activity_label": "Mentions",
+                        "activity_value": 1220,
+                        "trend": "rising",
+                        "has_data": True,
+                    }
+                ],
+            },
+        }
+    )
+
+    assert "Retail Sentiment Insights" in html
+    assert "Average Buzz" in html
+    assert "74.4/100" in html
+    assert "Bullish alignment" in html


### PR DESCRIPTION
## Summary

- add optional **Retail Sentiment Insights** to the finrobot_equity workflow
- fetch structured public-retail sentiment snapshots across Reddit, X.com, and Polymarket
- pass the snapshot into the existing news-summary generation flow as supplemental context
- render the insights in the professional HTML report, combined HTML report, legacy HTML pages, and PDF output
- keep the feature gated behind `adanos_api_key` / `ADANOS_API_KEY`, so the existing report flow stays unchanged when it is not configured

## Why

finrobot_equity already produces a strong equity-research workflow around fundamentals, valuation, charts, and recent news.

What it currently lacks is a compact view of how strongly a stock is being discussed by retail/public market participants, and whether that attention is aligned or diverging across channels.

This patch adds that as a supplemental insight layer, not as a replacement for the current news pipeline.

The new section highlights:
- average buzz
- bullish average
- source alignment
- source coverage
- per-source activity and trend across Reddit, X.com, and Polymarket

## Scope

This PR intentionally does not:
- replace FMP news or market-data flows
- add a new top-level FinRobot agent
- change the overall report structure outside of the existing news/events surface
- require the feature for normal usage

## Validation

Ran locally with:

- `PYTHONPATH=finrobot_equity/core/src python3 -m pytest finrobot_equity/core/tests -q`
- `python3 -m compileall finrobot_equity/core/src finrobot_equity/core/tests`

Both passed for the touched finrobot_equity core module.
