### PR TITLE
Guard coding tools against workspace escapes

### DIFF
--- a/finrobot/functional/coding.py
+++ b/finrobot/functional/coding.py
@@ -1,8 +1,22 @@
 import os
+from pathlib import Path
 from typing_extensions import Annotated
 from IPython import get_ipython
 
 default_path = "coding/"
+
+
+def _resolve_workspace_path(path: str) -> Path:
+    """Resolve a user-provided path and ensure it stays inside the coding workspace."""
+    workspace = Path(default_path).resolve()
+    resolved_path = (workspace / path).resolve()
+    try:
+        common_path = os.path.commonpath([str(workspace), str(resolved_path)])
+    except ValueError as exc:
+        raise ValueError(f"Path escapes the coding workspace: {path}") from exc
+    if common_path != str(workspace):
+        raise ValueError(f"Path escapes the coding workspace: {path}")
+    return resolved_path
 
 
 class IPythonUtils:
@@ -41,14 +55,14 @@ class CodingUtils:  # Borrowed from https://microsoft.github.io/autogen/docs/not
         """
         List files in choosen directory.
         """
-        files = os.listdir(default_path + directory)
+        files = os.listdir(_resolve_workspace_path(directory))
         return str(files)
 
     def see_file(filename: Annotated[str, "Name and path of file to check."]) -> str:
         """
         Check the contents of a chosen file.
         """
-        with open(default_path + filename, "r") as file:
+        with open(_resolve_workspace_path(filename), "r") as file:
             lines = file.readlines()
         formatted_lines = [f"{i+1}:{line}" for i, line in enumerate(lines)]
         file_contents = "".join(formatted_lines)
@@ -67,7 +81,7 @@ class CodingUtils:  # Borrowed from https://microsoft.github.io/autogen/docs/not
         """
         Replace old piece of code with new one. Proper indentation is important.
         """
-        with open(default_path + filename, "r+") as file:
+        with open(_resolve_workspace_path(filename), "r+") as file:
             file_contents = file.readlines()
             file_contents[start_line - 1 : end_line] = [new_code + "\n"]
             file.seek(0)
@@ -82,8 +96,8 @@ class CodingUtils:  # Borrowed from https://microsoft.github.io/autogen/docs/not
         """
         Create a new file with provided code.
         """
-        directory = os.path.dirname(default_path + filename)
-        os.makedirs(directory, exist_ok=True)
-        with open(default_path + filename, "w") as file:
+        file_path = _resolve_workspace_path(filename)
+        os.makedirs(file_path.parent, exist_ok=True)
+        with open(file_path, "w") as file:
             file.write(code)
         return "File created successfully"

--- a/tests/test_coding_utils.py
+++ b/tests/test_coding_utils.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+CODING_PATH = Path(__file__).parents[1] / "finrobot" / "functional" / "coding.py"
+SPEC = importlib.util.spec_from_file_location("coding", CODING_PATH)
+coding = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(coding)
+CodingUtils = coding.CodingUtils
+
+
+def test_create_file_with_code_writes_inside_workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = CodingUtils.create_file_with_code("reports/analysis.py", "print('ok')")
+
+    assert result == "File created successfully"
+    assert (tmp_path / "coding" / "reports" / "analysis.py").read_text() == "print('ok')"
+
+
+def test_create_file_with_code_rejects_parent_traversal(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="Path escapes the coding workspace"):
+        CodingUtils.create_file_with_code("../escape.py", "print('bad')")
+
+    assert not (tmp_path / "escape.py").exists()
+
+
+def test_modify_code_rejects_parent_traversal(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "outside.py").write_text("print('unchanged')\n")
+
+    with pytest.raises(ValueError, match="Path escapes the coding workspace"):
+        CodingUtils.modify_code("../outside.py", 1, 1, "print('changed')")
+
+    assert (tmp_path / "outside.py").read_text() == "print('unchanged')\n"


### PR DESCRIPTION
## Summary
- resolve CodingUtils paths against the configured coding workspace before file operations
- reject paths that escape the workspace boundary before listing, reading, modifying, or creating files
- add regression tests for normal file creation plus traversal attempts through create and modify tools

Closes #101.
Closes #102.

## Validation
- `python -m pytest tests\test_coding_utils.py -q`
- `python -m py_compile finrobot\functional\coding.py tests\test_coding_utils.py`
- `git diff --check`