### PR TITLE
Use stable FMP SEC filings endpoint

### DIFF
--- a/finrobot/data_source/fmp_utils.py
+++ b/finrobot/data_source/fmp_utils.py
@@ -25,6 +25,24 @@ def init_fmp_api(func):
     return wrapper
 
 
+def _get_filing_date(filing):
+    accepted_date = filing.get("acceptedDate") or ""
+    return (
+        filing.get("filingDate")
+        or filing.get("fillingDate")
+        or accepted_date.split(" ")[0]
+    )
+
+
+def _get_filing_link(filing):
+    return filing.get("finalLink") or filing.get("link") or filing.get("documentUrl")
+
+
+def _is_annual_report(filing):
+    form_type = filing.get("formType") or filing.get("type") or filing.get("form")
+    return form_type is not None and str(form_type).upper() == "10-K"
+
+
 @decorate_all_methods(init_fmp_api)
 class FMPUtils:
 
@@ -71,30 +89,57 @@ class FMPUtils:
     ) -> str:
         """Get the url and filing date of the 10-K report for a given stock and year"""
 
-        url = f"https://financialmodelingprep.com/api/v3/sec_filings/{ticker_symbol}?type=10-k&page=0&apikey={fmp_api_key}"
+        url = "https://financialmodelingprep.com/stable/sec-filings-search/symbol"
+        today = datetime.today().strftime("%Y-%m-%d")
+        params = {
+            "symbol": ticker_symbol,
+            "from": "1990-01-01" if fyear == "latest" else f"{fyear}-01-01",
+            "to": today if fyear == "latest" else f"{fyear}-12-31",
+            "page": 0,
+            "limit": 100,
+            "apikey": fmp_api_key,
+        }
 
         # 发送GET请求
-        filing_url = None
-        response = requests.get(url)
+        filings = []
+        for page in range(10):
+            params["page"] = page
+            response = requests.get(url, params=params)
 
-        # 确保请求成功
-        if response.status_code == 200:
+            # 确保请求成功
+            if response.status_code != 200:
+                return f"Failed to retrieve data: {response.status_code}"
+
             # 解析JSON数据
             data = response.json()
-            # print(data)
-            if fyear == "latest":
-                filing_url = data[0]["finalLink"]
-                filing_date = data[0]["fillingDate"]
-            else:
-                for filing in data:
-                    if filing["fillingDate"].split("-")[0] == fyear:
-                        filing_url = filing["finalLink"]
-                        filing_date = filing["fillingDate"]
-                        break
+            if not isinstance(data, list) or not data:
+                if page == 0:
+                    return f"No SEC filings found for {ticker_symbol}"
+                break
 
-            return f"Link: {filing_url}\nFiling Date: {filing_date}"
-        else:
-            return f"Failed to retrieve data: {response.status_code}"
+            filings.extend(
+                filing
+                for filing in data
+                if _is_annual_report(filing)
+                and _get_filing_date(filing)
+                and _get_filing_link(filing)
+                and (
+                    fyear == "latest"
+                    or _get_filing_date(filing).split("-")[0] == fyear
+                )
+            )
+            if filings or len(data) < params["limit"]:
+                break
+
+        filings.sort(key=_get_filing_date, reverse=True)
+
+        if not filings:
+            return f"No 10-K SEC filing found for {ticker_symbol}"
+
+        filing_url = _get_filing_link(filings[0])
+        filing_date = _get_filing_date(filings[0])
+
+        return f"Link: {filing_url}\nFiling Date: {filing_date}"
 
     def get_historical_market_cap(
         ticker_symbol: Annotated[str, "ticker symbol"],

--- a/tests/test_fmp_utils.py
+++ b/tests/test_fmp_utils.py
@@ -1,0 +1,125 @@
+import importlib.util
+from pathlib import Path
+
+
+FMP_UTILS_PATH = Path(__file__).parents[1] / "finrobot" / "data_source" / "fmp_utils.py"
+SPEC = importlib.util.spec_from_file_location(
+    "finrobot.data_source.fmp_utils", FMP_UTILS_PATH
+)
+fmp_utils = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fmp_utils)
+FMPUtils = fmp_utils.FMPUtils
+
+
+class MockResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def test_get_sec_report_uses_stable_symbol_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        return MockResponse(
+            [
+                {
+                    "formType": "10-Q",
+                    "filingDate": "2024-05-03",
+                    "link": "https://www.sec.gov/Archives/example-10q.htm",
+                },
+                {
+                    "formType": "10-K",
+                    "filingDate": "2024-02-02",
+                    "link": "https://www.sec.gov/Archives/example-10k.htm",
+                },
+            ]
+        )
+
+    monkeypatch.setenv("FMP_API_KEY", "test-key")
+    monkeypatch.setattr(fmp_utils.requests, "get", fake_get)
+
+    result = FMPUtils.get_sec_report("AAPL")
+
+    assert captured["url"] == (
+        "https://financialmodelingprep.com/stable/sec-filings-search/symbol"
+    )
+    assert captured["params"]["symbol"] == "AAPL"
+    assert captured["params"]["from"] == "1990-01-01"
+    assert captured["params"]["apikey"] == "test-key"
+    assert result == (
+        "Link: https://www.sec.gov/Archives/example-10k.htm\n"
+        "Filing Date: 2024-02-02"
+    )
+
+
+def test_get_sec_report_filters_year_and_supports_legacy_fields(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None):
+        captured["params"] = params
+        return MockResponse(
+            [
+                {
+                    "type": "10-K",
+                    "fillingDate": "2023-02-03",
+                    "finalLink": "https://www.sec.gov/Archives/legacy-10k.htm",
+                }
+            ]
+        )
+
+    monkeypatch.setenv("FMP_API_KEY", "test-key")
+    monkeypatch.setattr(fmp_utils.requests, "get", fake_get)
+
+    result = FMPUtils.get_sec_report("MSFT", "2023")
+
+    assert captured["params"]["from"] == "2023-01-01"
+    assert captured["params"]["to"] == "2023-12-31"
+    assert result == (
+        "Link: https://www.sec.gov/Archives/legacy-10k.htm\n"
+        "Filing Date: 2023-02-03"
+    )
+
+
+def test_get_sec_report_checks_next_page_for_annual_report(monkeypatch):
+    calls = []
+
+    def fake_get(url, params=None):
+        calls.append(params.copy())
+        if params["page"] == 0:
+            return MockResponse(
+                [
+                    {
+                        "formType": "4",
+                        "filingDate": "2025-01-02",
+                        "link": "https://www.sec.gov/Archives/insider.htm",
+                    }
+                    for _ in range(params["limit"])
+                ]
+            )
+
+        return MockResponse(
+            [
+                {
+                    "formType": "10-K",
+                    "filingDate": "2024-11-01",
+                    "link": "https://www.sec.gov/Archives/page-two-10k.htm",
+                }
+            ]
+        )
+
+    monkeypatch.setenv("FMP_API_KEY", "test-key")
+    monkeypatch.setattr(fmp_utils.requests, "get", fake_get)
+
+    result = FMPUtils.get_sec_report("AAPL")
+
+    assert [call["page"] for call in calls] == [0, 1]
+    assert result == (
+        "Link: https://www.sec.gov/Archives/page-two-10k.htm\n"
+        "Filing Date: 2024-11-01"
+    )


### PR DESCRIPTION
## Summary
- migrate `FMPUtils.get_sec_report` from the legacy `/api/v3/sec_filings/{symbol}` URL to FMP's stable SEC filings symbol search endpoint
- filter symbol search results down to 10-K filings and support both stable (`filingDate`, `link`) and legacy (`fillingDate`, `finalLink`) response fields
- page through capped symbol results so active companies still find the latest annual filing when the first page only contains other form types
- add focused tests for the stable URL, year filtering, legacy field compatibility, and pagination

## Why
FMP now documents SEC filings under the stable API namespace, including `https://financialmodelingprep.com/stable/sec-filings-search/symbol?symbol=AAPL&from=...&to=...`. The old `/api/v3/sec_filings/{symbol}` endpoint can return 403 for new FMP users, which is the failure reported in #73.

Closes #73.

## Tests
- `python -m pytest tests\\test_fmp_utils.py -q`
- `python -m py_compile finrobot\\data_source\\fmp_utils.py tests\\test_fmp_utils.py`
- `git diff --check` (Windows CRLF warning only)